### PR TITLE
Use correct import for `MonadPlus` and `msum`

### DIFF
--- a/Data/Set/ExtraG.hs
+++ b/Data/Set/ExtraG.hs
@@ -4,7 +4,7 @@ module Data.Set.ExtraG
     ) where
 
 import Data.Generics hiding (GT)
-import Control.Monad.Reader
+import Control.Monad (MonadPlus, msum)
 import Data.Set (Set, fromList)
 
 gFind :: forall a b. (Data a, Typeable b, Ord b) => a -> Set b


### PR DESCRIPTION
Prior to version 2.3, `mtl` used to re-export `Control.Monad` from `Control.Monad.Reader` (and other modules).  [This was changed in 2.3][changelog], unfortunately resulting in our module `Data.Set.ExtraG` failing to build with higher versions of `mtl`.

    set-extra     > [1 of 2] Compiling Data.Set.ExtraG
    set-extra     >
    set-extra     > /tmp/stack-77f809be85d63901/set-extra-1.4.1/Data/Set/ExtraG.hs:17:12: error: [GHC-76037]
    set-extra     >     Not in scope: type constructor or class ‘MonadPlus’
    set-extra     >    |
    set-extra     > 17 | gFind' :: (MonadPlus m, Data a, Typeable b) => a -> m b
    set-extra     >    |            ^^^^^^^^^

We only use two symbols from `Control.Monad.Reader`, namely `MonadPlus` and `msum`, and these are via its former re-export of `Control.Monad`.  This patch changes the import of `Control.Monad.Reader` to an import of `Control.Monad` and those specific symbols.

[changelog]: https://hackage.haskell.org/package/mtl-2.3.1/changelog#23----2022-05-07